### PR TITLE
Added Getting started example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Semantic UI requries some components to be initialized or they will not work (Dr
 Refer to the Usage sections in a module on how to initialize each element eg: [Semantic UI Accordion Usage](http://semantic-ui.com/modules/accordion.html#/usage)
 
 Example of initializing a dropdown using a template helper
-```
+```javascript
 Template.myDropdown.rendered = function() {
   // be sure to use this.$ so it is scoped to the template instead of to the window
   this.$('.ui.dropdown').dropdown({on: 'hover'});
@@ -33,7 +33,7 @@ Template.myDropdown.rendered = function() {
 ```
 
 Abstracted version which you use on any template helper
-```
+```javascript
 initAccordions(templ) {
   template.$('.ui.accordion').accordion();
 }
@@ -51,7 +51,7 @@ custom.semantic.json
 
 `custom.semantic.json` is the most important file. If it is empty, `semantic:ui` will generate the content with all the definitions and themes. By default, it sets to true all definitions and the theme "default".
 
-```
+```json
 {
   "definitions": {
     "accordion": true,

--- a/README.md
+++ b/README.md
@@ -18,6 +18,34 @@ Usage
 
 > Note: if you are happy with the default values you will need to remove `.custom.semantic.json` to generate Semantic UI. (see Generating Trigger)
 
+Getting Started & Initializing Modules
+-----
+Semantic UI requries some components to be initialized or they will not work (Dropdowns, Menus, Accordions, etc)
+Refer to the Usage sections in a module on how to initialize each element eg: [Semantic UI Accordion Usage](http://semantic-ui.com/modules/accordion.html#/usage)
+
+Example of initializing a dropdown using a template helper
+```
+Template.myDropdown.rendered = function() {
+  // be sure to use this.$ so it is scoped to the template instead of to the window
+  this.$('.ui.dropdown').dropdown({on: 'hover'});
+  // other SUI modules initialization
+};
+```
+
+Abstracted version which you use on any template helper
+```
+initAccordions(templ) {
+  template.$('.ui.accordion').accordion();
+}
+initDropdowns(template) {
+  template.$('.ui.dropdown').dropdown({on: 'hover'});
+}
+
+Template.myDropdown.rendered = function() {
+  initDropdowns(this);
+}
+```
+
 custom.semantic.json
 --------------------
 


### PR DESCRIPTION
I added some examples around initializing components due to some confusion around why dropdowns, accordions, etc do not get initialized automatically re: https://github.com/Semantic-Org/Semantic-UI/issues/1618#issuecomment-147094172
Hopefully this will cut down on the "non-issue" issues that get created for "my dropdown, toggle etc doesn't show properly..."
